### PR TITLE
Bugfix: response.code should be response.status_code

### DIFF
--- a/sync-zone.py
+++ b/sync-zone.py
@@ -452,7 +452,7 @@ if args.perform_sync:
         if error:
             sys.exit(1)
     else:
-        print("* Error:", sync_response.code, sync_response.reason)
+        print("* Error:", sync_response.status_code, sync_response.reason)
         print(sync_response.text)
         sys.exit(1)
 else:


### PR DESCRIPTION
Affects https://github.com/pwaring/dns-sync-zone/issues/24#issuecomment-597133372