### PR TITLE
Fixes for DNSAPIv1 changes as of 2020-04-06

### DIFF
--- a/sync-zone.py
+++ b/sync-zone.py
@@ -98,6 +98,11 @@ list_response = api.list()
 # rstrip needed as Mythic adds a trailing space to the LIST responses
 list_records = [l.rstrip() for l in list_response.text.splitlines()]
 
+# collapse repeated whitespace into single space [MB178014]
+list_records = [" ".join(l.split()) for l in list_records]
+# remove extra quoted quotes in returned [MB178014]
+list_records = [l.replace('\\"', '') for l in list_records]
+
 # Create DELETE [record] commands for all existing records returned by LIST,
 # except NS and SOA records
 


### PR DESCRIPTION
The DNSAPI has started sending double spaces in between a record type
and data, along with many layers of quoted quotes.  This strips them
back to a valid entry.