### PR TITLE
Allow hostnames to start with a digit character 

### DIFF
--- a/test_zone_validate.py
+++ b/test_zone_validate.py
@@ -465,10 +465,14 @@ class TextDNSValidate(unittest.TestCase):
     def test_validate_zone_record_bad_hostname(self):
         self.assertFalse(V.validate_zone_record("ADD 123 10 A 12.13.24.15"))
         self.assertFalse(V.validate_zone_record("ADD host- 10 A 12.13.24.15"))
-    
+
     def test_validate_zone_record_allow_underscore(self):
         # _host.example.org is permitted in DNS, even though some resolvers don't like it
         self.assertTrue(V.validate_zone_record("ADD _host 10 A 12.13.24.15"))
+
+    def test_validate_zone_record_allow_numeric(self):
+        self.assertTrue(V.validate_zone_record("ADD 111 300 A 127.0.0.1"))
+        self.assertTrue(V.validate_zone_record("ADD 111 300 AAAA ::1"))
 
     def test_validate_zone_record_nonstrict_hostname(self):
         self.assertTrue(V.validate_zone_record("ADD _host 10 TXT 12.13.24.15"))

--- a/test_zone_validate.py
+++ b/test_zone_validate.py
@@ -463,16 +463,16 @@ class TextDNSValidate(unittest.TestCase):
         )
 
     def test_validate_zone_record_bad_hostname(self):
-        self.assertFalse(V.validate_zone_record("ADD 123 10 A 12.13.24.15"))
+        # self.assertFalse(V.validate_zone_record("ADD 123 10 A 12.13.24.15"))
         self.assertFalse(V.validate_zone_record("ADD host- 10 A 12.13.24.15"))
 
     def test_validate_zone_record_allow_underscore(self):
         # _host.example.org is permitted in DNS, even though some resolvers don't like it
         self.assertTrue(V.validate_zone_record("ADD _host 10 A 12.13.24.15"))
 
-    def test_validate_zone_record_allow_numeric(self):
+    def test_validate_zone_record_allow_digit_start_hostname(self):
+        # RFC 1123 permits hostname labels to start with digits
         self.assertTrue(V.validate_zone_record("ADD 111 300 A 127.0.0.1"))
-        self.assertTrue(V.validate_zone_record("ADD 111 300 AAAA ::1"))
 
     def test_validate_zone_record_nonstrict_hostname(self):
         self.assertTrue(V.validate_zone_record("ADD _host 10 TXT 12.13.24.15"))

--- a/zone_validate.py
+++ b/zone_validate.py
@@ -55,6 +55,11 @@ def is_valid_name(name, strict=True):
         # Remove the wildcard for validation purposes, then check the remaining name
         name = name[2:]
 
+    # RFC 1123 permits hostname labels to start with digits
+    if name[0] in string.digits:
+        # Forcing first to an alpha char allows label validation to remain simple
+        name = "d" + name[1:]
+
     return is_valid_domain(name, strict=strict)
 
 


### PR DESCRIPTION
- The second example given fails testing because of the loopback ::1
- This change causes the test I've commented out to fail, which I'm
  assuming was an invalid test since the hostname can be numeric

Fixes #48